### PR TITLE
Allow using Python 3 to build GCR

### DIFF
--- a/app-crypt/gcr/gcr-3.34.0.ebuild
+++ b/app-crypt/gcr/gcr-3.34.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 VALA_USE_DEPEND="vapigen"
-PYTHON_COMPAT=( python2_7 )
+PYTHON_COMPAT=( python3_{5,6,7,8} )
 
 inherit gnome2 python-any-r1 vala virtualx
 


### PR DESCRIPTION
Since 3.34, GCR works with Python 3.

https://gitlab.gnome.org/GNOME/gcr/merge_requests/2
https://gitlab.gnome.org/GNOME/gcr/merge_requests/21

As at least one shebang now forces the use of Python 3, so I think that we should fully remove Python 2 as a possible `PYTHON_COMPAT` version.